### PR TITLE
Add React Native mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ An AI-powered news agent that fetches, processes, and delivers news using OpenAI
 - `npm run dev` - Start the development server with hot-reload
 - `npm test` - Run tests (not implemented yet)
 
+## Mobile App
+
+The `mobile` directory contains a React Native application using Expo.
+To run the mobile app:
+
+```bash
+cd mobile
+npm install
+npm start
+```
+
 ## Project Structure
 
 ```
@@ -35,6 +46,7 @@ ai-news-agent/
 ├── src/
 │   ├── index.js          # Main application entry point
 │   └── firebaseClient.js # Firebase client configuration
+├── mobile/               # React Native mobile application
 ├── .env.example          # Example environment variables
 ├── package.json          # Project dependencies and scripts
 └── README.md             # This file

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.expo/

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+
+import NewsFeed from './screens/NewsFeed';
+import SettingsScreen from './screens/SettingsScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={NewsFeed} />
+        <Tab.Screen name="Settings" component={SettingsScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "ai-news-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.8",
+    "react-native-safe-area-context": "4.5.0",
+    "react-native-screens": "~3.24.0"
+  }
+}

--- a/mobile/screens/NewsFeed.js
+++ b/mobile/screens/NewsFeed.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, ActivityIndicator, StyleSheet } from 'react-native';
+
+const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL || 'http://localhost:3000';
+
+export default function NewsFeed() {
+  const [news, setNews] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`${BACKEND_URL}/news`);
+        if (!res.ok) {
+          throw new Error('Failed to fetch news');
+        }
+        const data = await res.json();
+        setNews(data);
+      } catch (err) {
+        console.error(err);
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text>Failed to load news.</Text>
+      </View>
+    );
+  }
+
+  const renderItem = ({ item }) => (
+    <View style={styles.card}>
+      <Text style={styles.title}>{item.title}</Text>
+      <Text style={styles.summary}>{item.summary}</Text>
+    </View>
+  );
+
+  return (
+    <FlatList
+      data={news}
+      keyExtractor={(item, index) => index.toString()}
+      renderItem={renderItem}
+      contentContainerStyle={styles.list}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  list: {
+    padding: 16,
+  },
+  card: {
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    marginBottom: 12,
+    elevation: 2,
+  },
+  title: {
+    fontWeight: 'bold',
+    marginBottom: 4,
+    fontSize: 16,
+  },
+  summary: {
+    color: '#555',
+  },
+});

--- a/mobile/screens/SettingsScreen.js
+++ b/mobile/screens/SettingsScreen.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+
+const BACKEND_URL = process.env.EXPO_PUBLIC_BACKEND_URL || 'http://localhost:3000';
+const USER_ID = 'testuser1';
+
+export default function SettingsScreen() {
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`${BACKEND_URL}/test-context?userId=${USER_ID}`);
+        if (!res.ok) {
+          throw new Error('Failed to fetch user info');
+        }
+        const data = await res.json();
+        setProfile(data.userProfile);
+      } catch (err) {
+        console.error(err);
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text>Failed to load user info.</Text>
+      </View>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <View style={styles.center}>
+        <Text>No user info available.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.name}>{profile.name}</Text>
+      <Text>{profile.role}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  name: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+});


### PR DESCRIPTION
## Summary
- initialize `mobile` expo app
- implement bottom tab navigation with Home and Settings tabs
- fetch news from `/news` in `NewsFeed`
- fetch user profile in `SettingsScreen`
- document mobile app usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68701e4d1168832b940e261b913690ca